### PR TITLE
Paste multiline text into a single bullet

### DIFF
--- a/bookmarklet.js
+++ b/bookmarklet.js
@@ -1,1 +1,2 @@
-(function(){let text=""; if(window.getSelection()!=''){text=window.getSelection().toString();}prompt("Press CTRL+C or CMD+C, then escape and paste into Roam.", "__"+text+"__ — via ["+document.title+"]("+location.href+") [[+Roam]]");})()
+(function(){let text="";if(window.getSelection()!=''){text=window.getSelection().toString().replace(/(\r\n|\n|\r)/gm,"\r")}
+let formatted="__"+text.split("\r").join("__\r__")+"__";prompt("Press CTRL+C or CMD+C, then escape and paste into Roam.",formatted+" — via ["+document.title+"]("+location.href+") [[+Roam]]")})()


### PR DESCRIPTION
Formats the copied text by replacing each newline character by a single `\r`, so that pasting into Roam looks a little like:
![image](https://user-images.githubusercontent.com/6334450/80770128-5d121500-8b1d-11ea-9736-4a0c65c073a4.png)
As opposed to:
![image](https://user-images.githubusercontent.com/6334450/80770167-859a0f00-8b1d-11ea-8913-38d3c225c419.png)

Thanks for the handy chrome extension :)